### PR TITLE
Fixed Andrej Karpathy's broken blog link.

### DIFF
--- a/tsne/index.md
+++ b/tsne/index.md
@@ -74,7 +74,7 @@ Some results of our experiments with t-SNE are available for download below. In 
 You may right-click on the images and select "Show image in new tab" to see a larger version of each of the images.
 
 <br />
-You may also be interested in these blog posts describing applications of t-SNE by [Andrej Karpathy](http://karpathy.ca/myblog/?p=707), [Paul Mineiro](http://www.machinedlearnings.com/2011/06/even-better-hashtag-similarity.html), [Alexander Fabisch](http://nbviewer.ipython.org/urls/gist.githubusercontent.com/AlexanderFabisch/1a0c648de22eff4a2a3e/raw/59d5bc5ed8f8bfd9ff1f7faa749d1b095aa97d5a/t-SNE.ipynb), [Justin Donaldson](http://scwn.net), [Henry Tan](http://www.codeproject.com/Tips/788739/Visualization-of-High-Dimensional-Data-using-t-SNE), and [Cyrille Rossant](https://beta.oreilly.com/learning/an-illustrated-introduction-to-the-t-sne-algorithm).
+You may also be interested in these blog posts describing applications of t-SNE by [Andrej Karpathy](https://karpathy.github.io/2014/07/02/visualizing-top-tweeps-with-t-sne-in-Javascript/), [Paul Mineiro](http://www.machinedlearnings.com/2011/06/even-better-hashtag-similarity.html), [Alexander Fabisch](http://nbviewer.ipython.org/urls/gist.githubusercontent.com/AlexanderFabisch/1a0c648de22eff4a2a3e/raw/59d5bc5ed8f8bfd9ff1f7faa749d1b095aa97d5a/t-SNE.ipynb), [Justin Donaldson](http://scwn.net), [Henry Tan](http://www.codeproject.com/Tips/788739/Visualization-of-High-Dimensional-Data-using-t-SNE), and [Cyrille Rossant](https://beta.oreilly.com/learning/an-illustrated-introduction-to-the-t-sne-algorithm).
 
 ---
 


### PR DESCRIPTION
The link: http://karpathy.ca/myblog/?p=707 is no longer working, so I updated it to: https://karpathy.github.io/2014/07/02/visualizing-top-tweeps-with-t-sne-in-Javascript/

Would you prefer the archive.org link instead? https://web.archive.org/web/20141010080652/http://karpathy.ca/myblog/?p=707