### PR TITLE
Add link to WebAssembly implementation of tSNE

### DIFF
--- a/_site/tsne/index.html
+++ b/_site/tsne/index.html
@@ -225,6 +225,10 @@ An accessible introduction to t-SNE and its variants is given in this <a href="h
       <td><a href="http://cs.stanford.edu/people/karpathy/tsnejs/">All platforms</a></td>
     </tr>
     <tr>
+      <td><strong>WebAssembly implementation</strong> <small>(by <a href="https://github.com/robertaboukhalil">Robert Aboukhalil</a>; <a href="https://tsne.sandbox.bio">online demonstration</a>)</small></td>
+      <td><a href="https://github.com/robertaboukhalil/tsne-sandbox">All platforms</a></td>
+    </tr>
+    <tr>
       <td><strong>Parametric t-SNE</strong> <small>(Matlab; <a href="../publications/papers/AISTATS_2009.pdf">see here</a>)</small></td>
       <td><a href="code/ptsne.tar.gz">All platforms</a></td>
     </tr>

--- a/tsne/index.md
+++ b/tsne/index.md
@@ -45,6 +45,7 @@ You are free to use, modify, or redistribute this software in any way you want, 
 **Java implementation** <small>(by Leif Jonsson)</small> | [All platforms](https://github.com/lejon/T-SNE-Java)
 **R implementation** <small>(by [Justin](http://scwn.net))</small> | [All platforms](http://cran.r-project.org/web/packages/tsne/)
 **JavaScript implementation** <small>(by [Andrej](http://cs.stanford.edu/people/karpathy/); [online demonstration](http://homepage.tudelft.nl/19j49/tsnejs/))</small> | [All platforms](http://cs.stanford.edu/people/karpathy/tsnejs/)
+**WebAssembly implementation** <small>(by [Robert Aboukhalil](https://github.com/robertaboukhalil/)); [online demonstration](https://tsne.sandbox.bio))</small> | [All platforms](https://github.com/robertaboukhalil/tsne-sandbox)
 **Parametric t-SNE** <small>(outdated; [see here](../publications/papers/AISTATS_2009.pdf))</small> | [All platforms](code/ptsne.tar.gz)
 **Barnes-Hut t-SNE** <small>(C++, Matlab, Python, [Torch](https://github.com/clementfarabet/manifold), and [R](https://github.com/jkrijthe/Rtsne) wrappers; see [here](../publications/papers/JMLR_2014.pdf))</small> | [All platforms](code/bh_tsne.tar.gz) / [Github](https://github.com/lvdmaaten/bhtsne/)
 **MNIST Dataset** | [Matlab file](code/mnist.zip)


### PR DESCRIPTION
Hi there!

In case you're interested, I recently released [tsne.sandbox.bio](https://tsne.sandbox.bio), which is an online tSNE demo using WebAssembly ([code here](https://github.com/robertaboukhalil/tsne-sandbox)). I built this by compiling [this bhtsne repo](https://github.com/lh3/bhtsne) (a fork of your repo) from C to WebAssembly, so it can run in the browser!

Robert
